### PR TITLE
Moved sys.exit to avoid unnecessary code duplication

### DIFF
--- a/src/rml/__init__.py
+++ b/src/rml/__init__.py
@@ -415,13 +415,13 @@ def main(
             render_auth_result(
                 AuthResult(status=AuthStatus.PLAN_REQUIRED), console=console
             )
-            sys.exit(1)
         elif e.response.status_code == 401:
             render_auth_result(
                 AuthResult(status=AuthStatus.ERROR),
                 console=console,
             )
-            sys.exit(1)
+
+        sys.exit(1)
 
     except ValueError as e:
         logger.error(


### PR DESCRIPTION
- Tiny cleanup I spotted while reading through the repo. No need to have the sys.exit line appear twic, just run it at the end (since all conditions run it anyway) 