### PR TITLE
Add test alias to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,9 @@ install-dev:
 
 unit-test: lint-check
 	pytest --durations=10 tests/unit/
-	
+
+test: unit-test
+
 bump-version:
 	@if [ -z "$(version)" ]; then \
 		echo "Error: version argument is required. Usage: make bump-version version=X.Y.Z"; \


### PR DESCRIPTION
- Similarly to how we have it set up in squash. Makes it easier to run tests by just typing `make test`