### PR TITLE
Install test group in install-dev target

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.12
+    rev: v0.12.0
     hooks:
       - id: ruff
         types_or: [ python, pyi ]

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install-test:
 	uv sync --locked --extra test
 
 install-dev:
-	uv sync --locked --extra dev
+	uv sync --locked --extra test --extra dev
 	pre-commit install
 	pre-commit autoupdate
 


### PR DESCRIPTION
Dev dependency group should be a superset of test. The updated make target ensures that