### PR TITLE
Quickfix/release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Build and Release
 
 on:
   workflow_dispatch
-  release:
-    types: [created]
 
 jobs:
   check-version-bump:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Build and Release
 
 on:
-  workflow_dispatch
+  release:
+    types: [created]
 
 jobs:
   check-version-bump:
@@ -21,14 +22,13 @@ jobs:
         run: |
           version=$(uv version --short)
           echo "version: $version"
-          echo "release tag: 0.1.7"
-          if [ "$version" != "0.1.7" ]; then
+          echo "release tag: ${{ github.event.release.tag_name }}"
+          if [ "$version" != "${{ github.event.release.tag_name }}" ]; then
             echo "❌ Version mismatch: pyproject.toml version does not match release tag. Please run 'make bump-version version=${{ github.event.release.tag_name }}' and commit the changes."
             exit 1
           else
             echo "✅ Version matches release tag."
           fi
-
 
   # Matrix items cannot access variable defined in an `env` section, but they can read outputs from other jobs.
   set-env-vars:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Build and Release
 
 on:
+  workflow_dispatch
   release:
     types: [created]
 
@@ -12,14 +13,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: '3.13'
-
-      - name: Install Package
-        run: |
-          pip install uv
+          version: "0.6.16"
+          enable-cache: true
 
       - name: Check Version
         run: |
@@ -32,6 +30,7 @@ jobs:
           else
             echo "✅ Version matches release tag."
           fi
+
 
   # Matrix items cannot access variable defined in an `env` section, but they can read outputs from other jobs.
   set-env-vars:
@@ -72,15 +71,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.6.16"
+          enable-cache: true
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version-file: 'pyproject.toml'
 
       - name: Install and build
         run: |
-          pip install uv
-          uv sync --locked
           source .venv/bin/activate
           make install
           make bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.6.16"
+          version: "0.7.2"
           enable-cache: true
 
       - name: Check Version
@@ -72,7 +72,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.6.16"
+          version: "0.7.2"
           enable-cache: true
 
       - name: Set up Python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
         run: |
           version=$(uv version --short)
           echo "version: $version"
-          echo "release tag: ${{ github.event.release.tag_name }}"
-          if [ "$version" != "${{ github.event.release.tag_name }}" ]; then
+          echo "release tag: "0.1.7"
+          if [ "$version" != 0.1.7" ]; then
             echo "❌ Version mismatch: pyproject.toml version does not match release tag. Please run 'make bump-version version=${{ github.event.release.tag_name }}' and commit the changes."
             exit 1
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           version=$(uv version --short)
           echo "version: $version"
           echo "release tag: "0.1.7"
-          if [ "$version" != 0.1.7" ]; then
+          if [ "$version" != "0.1.7" ]; then
             echo "❌ Version mismatch: pyproject.toml version does not match release tag. Please run 'make bump-version version=${{ github.event.release.tag_name }}' and commit the changes."
             exit 1
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,8 @@ jobs:
 
       - name: Install and build
         run: |
-          source .venv/bin/activate
           make install
+          source .venv/bin/activate
           make bundle
 
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           version=$(uv version --short)
           echo "version: $version"
-          echo "release tag: "0.1.7"
+          echo "release tag: 0.1.7"
           if [ "$version" != "0.1.7" ]; then
             echo "❌ Version mismatch: pyproject.toml version does not match release tag. Please run 'make bump-version version=${{ github.event.release.tag_name }}' and commit the changes."
             exit 1

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,6 @@ bundle:
 	  tar -czf dist/$$TAR_NAME -C dist rml/;'
 
 install:
-	pyenv install 3.11.9 || true
-	pyenv local 3.11.9
-	curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/$(UV_VERSION)/uv-installer.sh | sh
 	uv sync --locked
 
 install-test:


### PR DESCRIPTION
1. Uses `astral-sh/setup-uv@v5` for installing UV
2. Ensures UV version consistency with `Makefile`
3. Uses `pyproject.toml` Python version, instead of hardcoding it.
4. Removes `pyenv` steps from `make install` as they break release action.

# Limitations

1. We still hardcode UV version in `.github/workflows/release.yaml`. We should find a way to ensure consistent UV version between `Makefile` and `.github/workflows/release.yaml`.