### PR TITLE
Unify timeout and set it to 300

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.10
+    rev: v0.12.11
     hooks:
       - id: ruff
         types_or: [ python, pyi ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rml"
-version = "0.1.12"
+version = "0.1.13"
 description = "CLI for Recurse ML"
 readme = "README.md"
 authors = [

--- a/src/rml/__init__.py
+++ b/src/rml/__init__.py
@@ -11,7 +11,6 @@ from httpx import (
     ConnectError,
     HTTPStatusError,
     RequestError,
-    Timeout,
     TimeoutException,
 )
 from plumbum import ProcessExecutionError, local
@@ -29,14 +28,12 @@ from rml.auth import get_env_value, require_auth
 from rml.datatypes import APICommentResponse, AuthResult, AuthStatus
 from rml.git import get_changed_files, get_git_root, raise_if_not_in_git_repo
 from rml.package_config import (
-    CONNECT_TIMEOUT,
     GET_CHECK_ROUTE,
     HEALTH_ROUTE,
     HOST,
     POST_CHECK_ROUTE,
-    READ_TIMEOUT,
     RECURSE_API_KEY_NAME,
-    WRITE_TIMEOUT,
+    TIMEOUT,
 )
 from rml.package_logger import logger
 from rml.ui import (
@@ -50,7 +47,7 @@ from rml.update import get_local_version, get_remote_version, update_and_rerun_r
 
 client = Client(
     base_url=HOST,
-    timeout=Timeout(CONNECT_TIMEOUT, read=READ_TIMEOUT, write=WRITE_TIMEOUT),
+    timeout=TIMEOUT,
 )
 
 

--- a/src/rml/package_config.py
+++ b/src/rml/package_config.py
@@ -34,8 +34,6 @@ POST_CHECK_ROUTE = "/api/check/"
 GET_CHECK_ROUTE = "/api/check/{check_id}/"
 HEALTH_ROUTE = "/health"
 
-CONNECT_TIMEOUT = int(os.getenv("U_CONNECT_TIMEOUT", "30"))
-READ_TIMEOUT = int(os.getenv("U_READ_TIMEOUT", "120"))
-WRITE_TIMEOUT = int(os.getenv("U_WRITE_TIMEOUT", "300"))
+TIMEOUT = int(os.getenv("U_TIMEOUT", "300"))
 
 SKIP_AUTH = False

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 
 [[package]]
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "rml"
-version = "0.1.12"
+version = "0.1.13"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
The most time consuming http call is `/api/check` POST request. When running it with the current timeout settings, it would still time out. That's because majority of the POST request falls under read rather than write timeout.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/f801b349af60fcf48c316acf4fece3520e63780a40d0154ee0b370b15f94222d/?repo_owner=Recurse-ML&repo_name=rml&pr_number=66)

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->